### PR TITLE
Add image-rich scaffolding with placeholder assets

### DIFF
--- a/public/placeholders/app-screenshot.svg
+++ b/public/placeholders/app-screenshot.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 390 844" role="img" aria-label="App screenshot placeholder">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="390" height="844" rx="44" fill="#000"/>
+  <rect x="8" y="8" width="374" height="828" rx="38" fill="url(#bg)"/>
+  <rect x="155" y="20" width="80" height="22" rx="11" fill="#000"/>
+  <rect x="24" y="80" width="180" height="18" rx="6" fill="#334155"/>
+  <rect x="24" y="110" width="120" height="12" rx="4" fill="#1e293b"/>
+  <rect x="24" y="150" width="342" height="160" rx="16" fill="#1e293b"/>
+  <rect x="24" y="330" width="342" height="80" rx="12" fill="#1e293b"/>
+  <rect x="24" y="430" width="342" height="80" rx="12" fill="#1e293b"/>
+  <rect x="24" y="530" width="342" height="80" rx="12" fill="#1e293b"/>
+  <rect x="24" y="780" width="342" height="40" rx="20" fill="#312e81"/>
+  <text x="195" y="430" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#64748b" text-anchor="middle" letter-spacing="2">SCREENSHOT</text>
+</svg>

--- a/public/placeholders/gallery-1.svg
+++ b/public/placeholders/gallery-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 1000" role="img" aria-label="Gallery placeholder">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#1e1b4b"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="1000" fill="url(#g1)"/>
+  <circle cx="600" cy="220" r="80" fill="#fbbf24" opacity="0.7"/>
+  <path d="M0 760 L260 540 L460 660 L800 420 L800 1000 L0 1000 Z" fill="#0f172a" opacity="0.7"/>
+  <text x="400" y="940" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" fill="#e0e7ff" text-anchor="middle" letter-spacing="3">PHOTO 01</text>
+</svg>

--- a/public/placeholders/gallery-2.svg
+++ b/public/placeholders/gallery-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" role="img" aria-label="Gallery placeholder">
+  <defs>
+    <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#082f49"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="800" fill="url(#g2)"/>
+  <rect x="120" y="200" width="200" height="400" fill="#0f172a" opacity="0.6"/>
+  <rect x="360" y="100" width="200" height="500" fill="#0f172a" opacity="0.6"/>
+  <rect x="600" y="260" width="120" height="340" fill="#0f172a" opacity="0.6"/>
+  <text x="400" y="740" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" fill="#e0f2fe" text-anchor="middle" letter-spacing="3">PHOTO 02</text>
+</svg>

--- a/public/placeholders/gallery-3.svg
+++ b/public/placeholders/gallery-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-label="Gallery placeholder">
+  <defs>
+    <linearGradient id="g3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#7c2d12"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#g3)"/>
+  <circle cx="220" cy="240" r="100" fill="#fde68a" opacity="0.8"/>
+  <path d="M0 460 L200 360 L420 420 L640 320 L800 380 L800 600 L0 600 Z" fill="#1c1917" opacity="0.7"/>
+  <text x="400" y="560" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" fill="#fff7ed" text-anchor="middle" letter-spacing="3">PHOTO 03</text>
+</svg>

--- a/public/placeholders/gallery-4.svg
+++ b/public/placeholders/gallery-4.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 1200" role="img" aria-label="Gallery placeholder">
+  <defs>
+    <linearGradient id="g4" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#10b981"/>
+      <stop offset="100%" stop-color="#064e3b"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="1200" fill="url(#g4)"/>
+  <circle cx="400" cy="500" r="180" fill="#0f172a" opacity="0.55"/>
+  <rect x="220" y="780" width="360" height="260" rx="20" fill="#0f172a" opacity="0.55"/>
+  <text x="400" y="1140" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" fill="#ecfdf5" text-anchor="middle" letter-spacing="3">PHOTO 04</text>
+</svg>

--- a/public/placeholders/gallery-5.svg
+++ b/public/placeholders/gallery-5.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" role="img" aria-label="Gallery placeholder">
+  <defs>
+    <linearGradient id="g5" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ec4899"/>
+      <stop offset="100%" stop-color="#500724"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="800" fill="url(#g5)"/>
+  <rect x="80" y="120" width="640" height="40" fill="#0f172a" opacity="0.4"/>
+  <rect x="80" y="200" width="640" height="40" fill="#0f172a" opacity="0.4"/>
+  <rect x="80" y="280" width="640" height="40" fill="#0f172a" opacity="0.4"/>
+  <rect x="80" y="360" width="640" height="40" fill="#0f172a" opacity="0.4"/>
+  <rect x="80" y="440" width="640" height="40" fill="#0f172a" opacity="0.4"/>
+  <text x="400" y="740" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" fill="#fdf2f8" text-anchor="middle" letter-spacing="3">PHOTO 05</text>
+</svg>

--- a/public/placeholders/gallery-6.svg
+++ b/public/placeholders/gallery-6.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 1000" role="img" aria-label="Gallery placeholder">
+  <defs>
+    <linearGradient id="g6" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#facc15"/>
+      <stop offset="100%" stop-color="#713f12"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="1000" fill="url(#g6)"/>
+  <circle cx="400" cy="400" r="160" fill="#1c1917" opacity="0.55"/>
+  <path d="M0 700 Q 400 600 800 700 L800 1000 L0 1000 Z" fill="#1c1917" opacity="0.7"/>
+  <text x="400" y="940" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" fill="#fefce8" text-anchor="middle" letter-spacing="3">PHOTO 06</text>
+</svg>

--- a/public/placeholders/hero-portrait.svg
+++ b/public/placeholders/hero-portrait.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 1000" role="img" aria-label="Hero portrait placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e1b4b"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+    <pattern id="dots" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1" fill="#6366f1" opacity="0.15"/>
+    </pattern>
+  </defs>
+  <rect width="800" height="1000" fill="url(#g)"/>
+  <rect width="800" height="1000" fill="url(#dots)"/>
+  <circle cx="400" cy="380" r="140" fill="#312e81" opacity="0.6"/>
+  <rect x="220" y="540" width="360" height="320" rx="40" fill="#312e81" opacity="0.6"/>
+  <text x="400" y="930" font-family="ui-sans-serif, system-ui, sans-serif" font-size="28" fill="#a5b4fc" text-anchor="middle" letter-spacing="2">PORTRAIT — 4:5</text>
+</svg>

--- a/public/placeholders/og-image.svg
+++ b/public/placeholders/og-image.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="OG image placeholder">
+  <defs>
+    <linearGradient id="og" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4338ca"/>
+      <stop offset="100%" stop-color="#000"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#og)"/>
+  <text x="80" y="300" font-family="ui-sans-serif, system-ui, sans-serif" font-size="72" fill="#fff" font-weight="700">Dave Kiribwa</text>
+  <text x="80" y="370" font-family="ui-sans-serif, system-ui, sans-serif" font-size="32" fill="#a5b4fc">Software engineer · DJ · Photographer</text>
+  <text x="80" y="560" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" fill="#818cf8" letter-spacing="4">odari.dev</text>
+</svg>

--- a/public/placeholders/project-cover.svg
+++ b/public/placeholders/project-cover.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="Project cover placeholder">
+  <defs>
+    <linearGradient id="cov" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4338ca"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#6366f1" stroke-opacity="0.15"/>
+    </pattern>
+  </defs>
+  <rect width="1600" height="900" fill="url(#cov)"/>
+  <rect width="1600" height="900" fill="url(#grid)"/>
+  <rect x="120" y="600" width="320" height="40" rx="8" fill="#a5b4fc" opacity="0.4"/>
+  <rect x="120" y="660" width="520" height="20" rx="6" fill="#a5b4fc" opacity="0.25"/>
+  <text x="800" y="470" font-family="ui-sans-serif, system-ui, sans-serif" font-size="48" fill="#e0e7ff" text-anchor="middle" letter-spacing="6" font-weight="700">PROJECT COVER</text>
+  <text x="800" y="520" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" fill="#a5b4fc" text-anchor="middle" letter-spacing="3">16:9</text>
+</svg>

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { FaGooglePlay } from "react-icons/fa";
+
+const SHOT = "/placeholders/app-screenshot.svg";
 
 const apps = [
   {
@@ -21,6 +24,7 @@ const apps = [
       "Clean Architecture",
       "Unit Testing",
     ],
+    screenshots: [SHOT, SHOT, SHOT],
     stores: [
       {
         label: "View on Play Store",
@@ -33,7 +37,8 @@ const apps = [
     role: "Software Engineer - Android",
     description:
       "Startup focusing on grocery delivery in under 10 minutes in select European countries.",
-    tech: ["Kotlin", "MVI", "BitriseCI","Unit Testing","Coroutines"],
+    tech: ["Kotlin", "MVI", "BitriseCI", "Unit Testing", "Coroutines"],
+    screenshots: [SHOT, SHOT, SHOT],
     stores: [
       {
         label: "View on Play Store (Customer App)",
@@ -50,7 +55,8 @@ const apps = [
     role: "Software Engineer II",
     description:
       "A fintech company dealing in trading of shares, crypto, and derivatives — and recently became a bank.",
-    tech: ["Kotlin", "Github Actions", "MVI", "Screenshot Testing","Paparazzi","Zendesk AI","RxJava"],
+    tech: ["Kotlin", "Github Actions", "MVI", "Screenshot Testing", "Paparazzi", "Zendesk AI", "RxJava"],
+    screenshots: [SHOT, SHOT, SHOT],
     stores: [
       {
         label: "View on Play Store",
@@ -62,7 +68,8 @@ const apps = [
     name: "Blacklane",
     role: "Software Engineer II",
     description: "A premium door-to-door chauffeur service.",
-    tech: ["Kotlin", "Firebase", "MVVM", "Github Actions", "Unit Testing","Roborazzi","Coroutines"],
+    tech: ["Kotlin", "Firebase", "MVVM", "Github Actions", "Unit Testing", "Roborazzi", "Coroutines"],
+    screenshots: [SHOT, SHOT, SHOT],
     stores: [
       {
         label: "View on Play Store (Guest App)",
@@ -88,8 +95,25 @@ export default function Experience() {
         {apps.map((app, i) => (
           <div
             key={i}
-            className="bg-white text-black p-6 rounded-xl shadow-md hover:shadow-lg transition"
+            className="bg-white text-black p-6 rounded-xl shadow-md hover:shadow-lg transition flex flex-col"
           >
+            <div className="grid grid-cols-3 gap-2 mb-5 -mx-2">
+              {app.screenshots.map((src, idx) => (
+                <div
+                  key={idx}
+                  className="relative aspect-[9/19] rounded-xl overflow-hidden bg-neutral-900"
+                >
+                  <Image
+                    src={src}
+                    alt={`${app.name} screenshot ${idx + 1} placeholder`}
+                    fill
+                    sizes="(max-width: 768px) 30vw, 150px"
+                    className="object-cover"
+                  />
+                </div>
+              ))}
+            </div>
+
             <h3 className="text-xl font-semibold mb-1">{app.name}</h3>
             <p className="text-sm text-gray-600 mb-2 italic">{app.role}</p>
             <p className="text-gray-700 mb-4">{app.description}</p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,35 @@
 import './globals.css';
+import type { Metadata } from 'next';
 import { Analytics } from '@vercel/analytics/next';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 
-export const metadata = {
+export const metadata: Metadata = {
+  metadataBase: new URL('https://odari.dev'),
   title: 'Dave Kiribwa | Developer Portfolio',
   description: 'Showcasing my software, side quests, and chaos.',
+  openGraph: {
+    title: 'Dave Kiribwa | Developer Portfolio',
+    description: 'Showcasing my software, side quests, and chaos.',
+    url: 'https://odari.dev',
+    siteName: 'odari.dev',
+    images: [
+      {
+        url: '/placeholders/og-image.svg',
+        width: 1200,
+        height: 630,
+        alt: 'Dave Kiribwa — software engineer, DJ, photographer',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Dave Kiribwa | Developer Portfolio',
+    description: 'Showcasing my software, side quests, and chaos.',
+    images: ['/placeholders/og-image.svg'],
+    creator: '@_davidodari',
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/life/page.tsx
+++ b/src/app/life/page.tsx
@@ -1,6 +1,16 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
+
+const gallery = [
+  { src: '/placeholders/gallery-1.svg', alt: 'Photo placeholder 01' },
+  { src: '/placeholders/gallery-2.svg', alt: 'Photo placeholder 02' },
+  { src: '/placeholders/gallery-3.svg', alt: 'Photo placeholder 03' },
+  { src: '/placeholders/gallery-4.svg', alt: 'Photo placeholder 04' },
+  { src: '/placeholders/gallery-5.svg', alt: 'Photo placeholder 05' },
+  { src: '/placeholders/gallery-6.svg', alt: 'Photo placeholder 06' },
+];
 
 export default function LifePage() {
   return (
@@ -79,6 +89,30 @@ export default function LifePage() {
               </Link>
             </li>
           </ul>
+        </div>
+      </div>
+
+      <div className="mt-20">
+        <h3 className="text-2xl font-semibold mb-2 text-center">Gallery</h3>
+        <p className="text-neutral-500 text-center mb-8 text-sm">
+          Placeholder tiles — swap in real shots from Unsplash or your library.
+        </p>
+        <div className="columns-2 md:columns-3 gap-4 [column-fill:_balance]">
+          {gallery.map((photo, i) => (
+            <div
+              key={i}
+              className="mb-4 break-inside-avoid rounded-xl overflow-hidden ring-1 ring-white/10 hover:ring-indigo-500/40 transition"
+            >
+              <Image
+                src={photo.src}
+                alt={photo.alt}
+                width={800}
+                height={1000}
+                sizes="(max-width: 768px) 50vw, 33vw"
+                className="w-full h-auto block"
+              />
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,43 +1,64 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import Image from 'next/image';
 import Link from 'next/link';
 
 export default function HomePage() {
   return (
-    <section className="min-h-screen flex flex-col justify-center items-center px-4 text-center">
-      <motion.h1
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-        className="text-4xl md:text-6xl font-bold mb-4"
-      >
-        Hey, I&#39;m Dave. 
-      </motion.h1>
+    <section className="min-h-screen flex items-center px-4 py-16">
+      <div className="max-w-6xl mx-auto grid md:grid-cols-2 gap-12 items-center w-full">
+        <div className="text-center md:text-left order-2 md:order-1">
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            className="text-4xl md:text-6xl font-bold mb-4"
+          >
+            Hey, I&#39;m Dave.
+          </motion.h1>
 
-      <motion.p
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.3, duration: 0.6 }}
-        className="text-lg md:text-xl text-neutral-400 max-w-xl mb-8"
-      >
-        Software engineer and lover of the arts.
-        I love my code like I love my home screen — clean, minimal, and only the essentials.
-        Find me on a DJ deck or behind a camera when I am not coding a.k.a telling AI what to do.
-      </motion.p>
+          <motion.p
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3, duration: 0.6 }}
+            className="text-lg md:text-xl text-neutral-400 max-w-xl mb-8 mx-auto md:mx-0"
+          >
+            Software engineer and lover of the arts.
+            I love my code like I love my home screen — clean, minimal, and only the essentials.
+            Find me on a DJ deck or behind a camera when I am not coding a.k.a telling AI what to do.
+          </motion.p>
 
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.6 }}
-      >
-        <Link
-          href="/projects"
-          className="inline-block px-6 py-3 rounded-md border border-indigo-500 text-indigo-400 hover:bg-indigo-500 hover:text-black transition"
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.6 }}
+          >
+            <Link
+              href="/projects"
+              className="inline-block px-6 py-3 rounded-md border border-indigo-500 text-indigo-400 hover:bg-indigo-500 hover:text-black transition"
+            >
+              View My Work
+            </Link>
+          </motion.div>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.7 }}
+          className="order-1 md:order-2 relative aspect-[4/5] max-w-sm mx-auto md:max-w-none w-full rounded-2xl overflow-hidden ring-1 ring-indigo-500/30 shadow-2xl shadow-indigo-500/10"
         >
-          View My Work
-        </Link>
-      </motion.div>
+          <Image
+            src="/placeholders/hero-portrait.svg"
+            alt="Portrait placeholder — drop a real photo here"
+            fill
+            priority
+            sizes="(max-width: 768px) 80vw, 480px"
+            className="object-cover"
+          />
+        </motion.div>
+      </div>
     </section>
   );
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import {
   FaGithub,
@@ -9,10 +10,11 @@ import {
   FaAndroid,
 } from "react-icons/fa";
 
+const COVER = "/placeholders/project-cover.svg";
+
 export default function Projects() {
   return (
     <section className="max-w-4xl mx-auto mt-20 px-4">
-      {/* Existing GitHub / App Store grid... */}
       <h2 className="text-4xl font-bold mb-4 text-center">Projects</h2>
       <p className="text-neutral-400 text-center mb-12 max-w-2xl mx-auto">
         Here’s where I ship stuff — apps, experiments, tools. Some are in the
@@ -21,56 +23,90 @@ export default function Projects() {
 
       <div className="grid md:grid-cols-2 gap-6">
         {/* GitHub */}
-        <div className="bg-white text-black p-6 rounded-2xl shadow-md hover:shadow-lg transition-shadow">
-          <h3 className="text-xl font-semibold mb-2 flex items-center gap-2">
-            <FaGithub /> GitHub
-          </h3>
-          <p className="text-gray-700 mb-4">
-            Explore my open source projects, experiments, and dev utilities.
-          </p>
-          <Link
-            href="https://github.com/odaridavid"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-indigo-600 hover:underline font-medium"
-          >
-            View on GitHub →
-          </Link>
+        <div className="bg-white text-black rounded-2xl shadow-md hover:shadow-lg transition-shadow overflow-hidden">
+          <div className="relative aspect-video bg-neutral-900">
+            <Image
+              src={COVER}
+              alt="GitHub cover placeholder"
+              fill
+              sizes="(max-width: 768px) 100vw, 400px"
+              className="object-cover"
+            />
+          </div>
+          <div className="p-6">
+            <h3 className="text-xl font-semibold mb-2 flex items-center gap-2">
+              <FaGithub /> GitHub
+            </h3>
+            <p className="text-gray-700 mb-4">
+              Explore my open source projects, experiments, and dev utilities.
+            </p>
+            <Link
+              href="https://github.com/odaridavid"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-indigo-600 hover:underline font-medium"
+            >
+              View on GitHub →
+            </Link>
+          </div>
         </div>
 
         {/* Play Store */}
-        <div className="bg-white text-black p-6 rounded-2xl shadow-md hover:shadow-lg transition-shadow">
-          <h3 className="text-xl font-semibold mb-2 flex items-center gap-2">
-            <FaGooglePlay /> Google Play
-          </h3>
-          <p className="text-gray-700 mb-4">
-            Android apps I have designed, developed, and published to the world.
-          </p>
-          <Link
-            href="https://play.google.com/store/apps/dev?id=8090138511631227064&hl=en"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-indigo-600 hover:underline font-medium"
-          >
-            See my apps →
-          </Link>
+        <div className="bg-white text-black rounded-2xl shadow-md hover:shadow-lg transition-shadow overflow-hidden">
+          <div className="relative aspect-video bg-neutral-900">
+            <Image
+              src={COVER}
+              alt="Google Play cover placeholder"
+              fill
+              sizes="(max-width: 768px) 100vw, 400px"
+              className="object-cover"
+            />
+          </div>
+          <div className="p-6">
+            <h3 className="text-xl font-semibold mb-2 flex items-center gap-2">
+              <FaGooglePlay /> Google Play
+            </h3>
+            <p className="text-gray-700 mb-4">
+              Android apps I have designed, developed, and published to the world.
+            </p>
+            <Link
+              href="https://play.google.com/store/apps/dev?id=8090138511631227064&hl=en"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-indigo-600 hover:underline font-medium"
+            >
+              See my apps →
+            </Link>
+          </div>
         </div>
+
         {/* Apple App Store */}
-        <div className="bg-white text-black p-6 rounded-2xl shadow-md hover:shadow-lg transition-shadow">
-          <h3 className="text-xl font-semibold mb-2 flex items-center gap-2">
-            <FaApple /> App Store
-          </h3>
-          <p className="text-gray-700 mb-4">
-            iOS apps for iPhone and iPad — built with KMP.
-          </p>
-          <Link
-            href="https://apps.apple.com/developer/david-odari-kiribwa/id1706468850"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-indigo-600 hover:underline font-medium"
-          >
-            Check App Store →
-          </Link>
+        <div className="bg-white text-black rounded-2xl shadow-md hover:shadow-lg transition-shadow overflow-hidden">
+          <div className="relative aspect-video bg-neutral-900">
+            <Image
+              src={COVER}
+              alt="App Store cover placeholder"
+              fill
+              sizes="(max-width: 768px) 100vw, 400px"
+              className="object-cover"
+            />
+          </div>
+          <div className="p-6">
+            <h3 className="text-xl font-semibold mb-2 flex items-center gap-2">
+              <FaApple /> App Store
+            </h3>
+            <p className="text-gray-700 mb-4">
+              iOS apps for iPhone and iPad — built with KMP.
+            </p>
+            <Link
+              href="https://apps.apple.com/developer/david-odari-kiribwa/id1706468850"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-indigo-600 hover:underline font-medium"
+            >
+              Check App Store →
+            </Link>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Drops `next/image` slots into the home, projects, experience, and life pages, backed by labelled SVG placeholders under `public/placeholders/`.
- Adds Open Graph + Twitter card metadata in the root layout pointing at a placeholder OG image, so link unfurls aren't bare.
- All routes remain `○ Static` after the change (verified via `npm run build`).

## What changed
| Page | Change |
| --- | --- |
| `/` | Two-column hero with a 4:5 portrait slot (stacked on mobile, priority loaded). |
| `/projects` | 16:9 cover image above each of the three top cards. |
| `/experience` | 3-up phone-frame screenshot mosaic above each app card. |
| `/life` | New masonry gallery (CSS columns) with 6 placeholder tiles of varied aspect ratios. |
| `layout.tsx` | `metadataBase`, `openGraph`, and `twitter` blocks added. |

## How to swap in real assets
Each placeholder is a labelled SVG under `public/placeholders/`. Replace the file (or change the `src` in the page) — no code changes needed past that. Real OG image should be a 1200×630 PNG/JPG for best social compatibility.

## Test plan
- [x] `npm run build` — succeeds, all 10 routes still static
- [ ] `npm run dev` and walk through `/`, `/projects`, `/experience`, `/life` at desktop + mobile widths
- [ ] Inspect `<head>` to confirm OG tags render
- [ ] Decide on real assets to swap in (portrait, app screenshots from Play Store listings, life photos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)